### PR TITLE
Fix highlighting and add helpers.js file

### DIFF
--- a/inner_join.html
+++ b/inner_join.html
@@ -68,6 +68,7 @@
   <script src="scripts/target_table.js"></script>
   <script src="scripts/inner_join_source_table.js"></script>
   <script src="scripts/error_list.js"></script>
+  <script src="scripts/helpers.js"></script>
   <script>
     const errorList = new ErrorList(
       document.getElementById("errorList"),

--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -1,0 +1,21 @@
+function getRowAndTable(cell) {
+    let row = cell.parentElement;
+    let body = row.parentElement;
+    let table = body.parentElement;
+    return [row, table];
+}
+
+function getDropTable(elementList) {
+    for (let i = 0; i < elementList.length; i++) {
+        let cell = elementList[i];
+        if (cell == null || cell.nodeName.toLowerCase() !== 'td') continue;
+
+        var [row, table] = getRowAndTable(cell);
+        if (row.nodeName.toLowerCase() === 'th') continue;
+
+        if (table.classList.contains('droppableTable')) 
+            return [cell, row, table];
+    }
+  
+    return null;
+}

--- a/scripts/source_table.js
+++ b/scripts/source_table.js
@@ -85,22 +85,18 @@ class SourceTable extends Table {
     this.targetRow = null;
     this.targetTable = null;
 
-    let targetCell = document.elementFromPoint(event.pageX, event.pageY);
-    if (targetCell == null || targetCell.nodeName.toLowerCase() !== 'td') return false;
+    let elementList = document.elementsFromPoint(event.pageX, event.pageY);
+    let tableTuple = getDropTable(elementList);
+    if(tableTuple == null) return false;
+    
+    var [cell, row, table] = tableTuple;
+    
 
-    let targetRow = targetCell.parentElement;
-    if (targetRow.nodeName.toLowerCase() === 'th') return false;
+    this.targetCell = cell;
+    this.targetRow = row;
+    this.targetTable = table;
 
-    let targetBody = targetRow.parentElement;
-    let targetTable = targetBody.parentElement;
-
-    if (!targetTable.classList.contains('droppableTable')) return false;
-
-    this.targetCell = targetCell;
-    this.targetRow = targetRow;
-    this.targetTable = targetTable;
-
-    this.targetRowID = [].slice.call(this.targetTable.querySelectorAll('tr')).indexOf(this.targetRow);
+    this.targetRowID = [].slice.call(this.table.querySelectorAll('tr')).indexOf(this.targetRow);
 
     return true;
   }


### PR DESCRIPTION
The bug happens because elementFromPoint() returns the element underneath a coordinate. And sometimes the row that is being dragged might stay under the cursor. We use element**s**FromPoint() (with an s) to return a list of elements instead 